### PR TITLE
StringRefをAstTokenRefに変更

### DIFF
--- a/src/ast/ast_impl.h
+++ b/src/ast/ast_impl.h
@@ -3,7 +3,7 @@
 
 #include "../ast.h"
 #include "ast_vector.h"
-#include "../stdstring.h"
+#include "ast_string.h"
 
 struct Ast {
   enum AstTag tag;
@@ -81,7 +81,7 @@ struct Ast {
     AstFunctionDefinitionRef function_definition;
 
     AstVectorRef vector;
-    StringRef token;
+    AstTokenRef token;
   } data;
 };
 

--- a/src/ast/ast_string.c
+++ b/src/ast/ast_string.c
@@ -31,7 +31,7 @@ void ast_string_allocator_ctor(void) {
   g_string_allocator.manager_ = ast_pool();
 }
 
-StringRef ast_make_string(const char* src, size_t length) {
+AstTokenRef ast_make_string(const char* src, size_t length) {
   return make_string(src, length, &g_string_allocator);
 }
 

--- a/src/ast/ast_string.h
+++ b/src/ast/ast_string.h
@@ -3,8 +3,10 @@
 
 #include "../stdstring.h"
 
+typedef StringRef AstTokenRef;
+
 void ast_string_allocator_ctor(void);
 
-StringRef ast_make_string(const char* src, size_t length);
+AstTokenRef ast_make_string(const char* src, size_t length);
 
 #endif  /* KMC_C89_COMPILER_AST_AST_STRING_H */

--- a/src/ast/get_method.c
+++ b/src/ast/get_method.c
@@ -578,7 +578,7 @@ AstVectorRef ast_get_vector(AstRef ast) {
   return NULL;
 }
 
-StringRef ast_get_token(AstRef ast) {
+AstTokenRef ast_get_token(AstRef ast) {
   assert(ast);
   if (ast_is_token(ast)) {
     return ast->data.token;

--- a/src/ast/get_method.h
+++ b/src/ast/get_method.h
@@ -76,6 +76,6 @@ AstExternalDeclarationRef ast_get_external_declaration(AstRef ast);
 AstFunctionDefinitionRef ast_get_function_definition(AstRef ast);
 
 AstVectorRef ast_get_vector(AstRef ast);
-StringRef ast_get_token(AstRef ast);
+AstTokenRef ast_get_token(AstRef ast);
 
 #endif  /* KMC_C89_COMPILER_AST_GET_METHOD_H */


### PR DESCRIPTION
命名規則に一貫性をもたせた。