### PR TITLE
parser.yのBNFが正しくない

### DIFF
--- a/src/parser.y
+++ b/src/parser.y
@@ -492,7 +492,7 @@ direct-abstract-declarator.opt
 direct-abstract-declarator
 : '(' abstract-declarator ')'
 | direct-abstract-declarator.opt '[' constant-expression ']'
-| direct-abstract-declarator.opt '[' parameter-type-list ']'
+| direct-abstract-declarator.opt '(' parameter-type-list ')'
 ;
 
 typedef-name


### PR DESCRIPTION
かっこの間違いを発見。