### PR TITLE
AstPointerを導入

### DIFF
--- a/src/ast.h
+++ b/src/ast.h
@@ -125,8 +125,8 @@ enum AstTag {
   AST_TAG_ENUM_END
 };
 
-typedef struct Ast* AstRef;
-typedef AstRef AstPointer;
+typedef struct Ast* AstRef;  /* NOT NULLABLE */
+typedef AstRef AstPointer;  /* NULLABLE */
 
 typedef struct AstIdentifier* AstIdentifierRef;
 typedef struct AstConstant* AstConstantRef;

--- a/src/ast.h
+++ b/src/ast.h
@@ -126,6 +126,7 @@ enum AstTag {
 };
 
 typedef struct Ast* AstRef;
+typedef AstRef AstPointer;
 
 typedef struct AstIdentifier* AstIdentifierRef;
 typedef struct AstConstant* AstConstantRef;


### PR DESCRIPTION
- `AstRef` はNULLを認めない状況で用いる。
- `AstPointer` はNULLを取りうる状況で用いる。