### PR TITLE
set_yyin_stringの定義を移動

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -6,6 +6,7 @@
 #include "ast/ast_string.h"
 #include "parser.tab.h"
 #include "ast_method.h"
+#include <stdlib.h>
 
 int yywrap(void) {
   return 1;

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -145,3 +145,7 @@ WHITESPACE ;
   exit(EXIT_FAILURE);
 }
 %%
+
+void set_yyin_string(const char *code) {
+  yy_scan_string(code);
+}

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -149,3 +149,12 @@ WHITESPACE ;
 void set_yyin_string(const char *code) {
   yy_scan_string(code);
 }
+
+void set_yyin_file(const char *filename) {
+  FILE* fp = fopen(filename, "r");
+  if (fp == NULL) {
+    printf("fatal error: failed to open %s\n", filename);
+    exit(EXIT_FAILURE);
+  }
+  yyin = fp;
+}

--- a/src/parser.y
+++ b/src/parser.y
@@ -807,14 +807,3 @@ function-definition
 void yyerror(const char* s) {
   fprintf(stderr, "%s\n", s);
 }
-
-extern FILE *yyin;
-
-void set_yyin_file(const char *filename) {
-  FILE* fp = fopen(filename, "r");
-  if (fp == NULL) {
-    printf("fatal error: failed to open %s\n", filename);
-    exit(EXIT_FAILURE);
-  }
-  yyin = fp;
-}

--- a/src/parser.y
+++ b/src/parser.y
@@ -1,6 +1,5 @@
 %code {
 #include <stdio.h>
-#include <stdlib.h>
 void yyerror(const char *);
 }
 

--- a/src/parser.y
+++ b/src/parser.y
@@ -818,7 +818,3 @@ void set_yyin_file(const char *filename) {
   }
   yyin = fp;
 }
-
-void set_yyin_string(const char *code) {
-  yy_scan_string(code);
-}


### PR DESCRIPTION
コンパイル時にyy_scan_stringがundeclaredだと警告されるので直す