### PR TITLE
ast_method.hをparser.yに導入

### DIFF
--- a/src/parser.y
+++ b/src/parser.y
@@ -1,5 +1,6 @@
 %code {
 #include <stdio.h>
+#include "ast_method.h"
 
 #define AST_ERROR(lhs, rhs) \
   do { \


### PR DESCRIPTION
parser.yでの作業に必要なので。
これで wass/* のCIが通り始めるはず。