### PR TITLE
Refine parser

### DIFF
--- a/src/parser.y
+++ b/src/parser.y
@@ -270,6 +270,10 @@ global-declaration
 | linkage-specifier declaration-specifiers init-declarator-list ';'
 ;
 
+typedef-declaration
+: typedef-specifier declaration-specifiers declarator-list ';'
+;
+
 declaration-specifiers.opt
 : %empty
 | declaration-specifiers
@@ -529,6 +533,7 @@ external-declaration
 : function-definition
 | type-declaration
 | global-declaration
+| typedef-declaration
 ;
 
 function-definition

--- a/src/parser.y
+++ b/src/parser.y
@@ -75,8 +75,6 @@ void set_yyin_string(const char *code);
 %token VOLATILE "volatile"
 %token WHILE "while"
 
-%precedence NO_INT
-%precedence INT
 %precedence ONLY_IF
 %precedence ELSE
 
@@ -276,14 +274,8 @@ typedef-declaration
 : typedef-specifier declaration-specifiers declarator-list ';'
 ;
 
-declaration-specifiers.opt
-: %empty
-| declaration-specifiers
-;
-
 declaration-specifiers
-: type-specifier declaration-specifiers.opt
-| type-qualifier declaration-specifiers.opt
+: type-qualifier-list.opt type-specifier type-qualifier-list.opt
 ;
 
 init-declarator-list
@@ -312,7 +304,7 @@ typedef-specifier
 ;
 
 int.opt
-: NO_INT
+: %empty
 | "int"
 ;
 

--- a/src/parser.y
+++ b/src/parser.y
@@ -486,6 +486,12 @@ direct-abstract-declarator
 | direct-abstract-declarator '(' parameter-declaration-list ',' "..." ')'
 ;
 
+array-abstract-declarator
+: '[' constant-expression.opt ']'
+| direct-abstract-declarator '[' constant-expression.opt ']'
+| array-abstract-declarator '[' constant-expression.opt ']'
+;
+
 initializer
 : assignment-expression
 | '{' initializer-list '}'

--- a/src/parser.y
+++ b/src/parser.y
@@ -283,11 +283,18 @@ init-declarator
 ;
 
 storage-class-specifier
-: "typedef"
-| "extern"
-| "static"
+: "static"
 | "auto"
 | "register"
+;
+
+linkage-specifier
+: "extern"
+| "static"
+;
+
+typedef-specifier
+: "typedef"
 ;
 
 type-specifier

--- a/src/parser.y
+++ b/src/parser.y
@@ -336,16 +336,26 @@ long-long-type
 | "signed" "long" "long" int.opt
 ;
 
-type-specifier
+fundamental-type-specifier
 : "void"
 | "char"
-| "short"
-| "int"
-| "long"
+| "signed" "char"
+| "unsigned" "char"
+| short-type
+| "unsigned" "short" int.opt
+| int-type
+| "unsigned" int.opt
+| long-type
+| "unsigned" "long" int.opt
+| long-long-type
+| "unsigned" "long" "long" int.opt
 | "float"
 | "double"
-| "signed"
-| "unsigned"
+| "long" "double"
+;
+
+type-specifier
+: fundamental-type-specifier
 | struct-or-union-specifier
 | enum-specifier
 | typedef-name

--- a/src/parser.y
+++ b/src/parser.y
@@ -492,6 +492,16 @@ array-abstract-declarator
 | array-abstract-declarator '[' constant-expression.opt ']'
 ;
 
+function-abstract-declarator
+: '(' parameter-declaration-list ')'
+| direct-abstract-declarator '(' parameter-declaration-list ')'
+;
+
+variadic-function-abstract-declarator
+: '(' parameter-declaration-list ',' "..." ')'
+| direct-abstract-declarator '(' parameter-declaration-list ',' "..." ')'
+;
+
 initializer
 : assignment-expression
 | '{' initializer-list '}'

--- a/src/parser.y
+++ b/src/parser.y
@@ -414,14 +414,14 @@ declarator-list
 
 declarator
 : pointer-list.opt direct-declarator
+| pointer-list.opt array-declarator
+| pointer-list.opt function-declarator
+| pointer-list.opt variadic-function-declarator
 ;
 
 direct-declarator
 : identifier
 | '(' declarator ')'
-| direct-declarator '[' constant-expression.opt ']'
-| direct-declarator '(' parameter-declaration-list ')'
-| direct-declarator '(' parameter-declaration-list ',' "..." ')'
 ;
 
 array-declarator

--- a/src/parser.y
+++ b/src/parser.y
@@ -373,21 +373,7 @@ struct-declaration-list
 ;
 
 struct-declaration
-: specifier-qualifier-list struct-declarator-list ';'
-;
-
-specifier-qualifier-list.opt
-: %empty
-| specifier-qualifier-list
-;
-
-specifier-qualifier-list
-: specifier-qualifier specifier-qualifier-list.opt
-;
-
-specifier-qualifier
-: type-specifier
-| type-qualifier
+: declaration-specifiers struct-declarator-list ';'
 ;
 
 struct-declarator-list
@@ -468,8 +454,8 @@ parameter-declaration
 ;
 
 type-name
-: specifier-qualifier-list
-| specifier-qualifier-list abstract-declarator
+: declaration-specifiers
+| declaration-specifiers abstract-declarator
 ;
 
 abstract-declarator

--- a/src/parser.y
+++ b/src/parser.y
@@ -424,6 +424,11 @@ direct-declarator
 | direct-declarator '(' parameter-declaration-list ',' "..." ')'
 ;
 
+array-declarator
+: direct-declarator '[' constant-expression.opt ']'
+| array-declarator '[' constant-expression.opt ']'
+;
+
 pointer-list.opt
 : %empty
 | pointer-list

--- a/src/parser.y
+++ b/src/parser.y
@@ -256,9 +256,12 @@ constant-expression
 : conditional-expression
 ;
 
-declaration
+type-declaration
 : declaration-specifiers ';'
-| declaration-specifiers init-declarator-list ';'
+;
+
+declaration
+: declaration-specifiers init-declarator-list ';'
 | storage-class-specifier declaration-specifiers init-declarator-list ';'
 ;
 
@@ -519,7 +522,7 @@ translation-unit
 
 external-declaration
 : function-definition
-| declaration
+| type-declaration
 ;
 
 function-definition

--- a/src/parser.y
+++ b/src/parser.y
@@ -392,6 +392,11 @@ type-qualifier
 | "volatile"
 ;
 
+declarator-list
+: declarator
+| declarator-list ',' declarator
+;
+
 declarator
 : pointer-list.opt direct-declarator
 ;

--- a/src/parser.y
+++ b/src/parser.y
@@ -75,6 +75,8 @@ void set_yyin_string(const char *code);
 %token VOLATILE "volatile"
 %token WHILE "while"
 
+%precedence NO_INT
+%precedence INT
 %precedence ONLY_IF
 %precedence ELSE
 
@@ -307,6 +309,11 @@ linkage-specifier
 
 typedef-specifier
 : "typedef"
+;
+
+int.opt
+: NO_INT
+| "int"
 ;
 
 type-specifier

--- a/src/parser.y
+++ b/src/parser.y
@@ -316,6 +316,26 @@ int.opt
 | "int"
 ;
 
+short-type
+: "short" int.opt
+| "signed" "short" int.opt
+;
+
+int-type
+: "int"
+| "signed" int.opt
+;
+
+long-type
+: "long" int.opt
+| "signed" "long" int.opt
+;
+
+long-long-type
+: "long" "long" int.opt
+| "signed" "long" "long" int.opt
+;
+
 type-specifier
 : "void"
 | "char"

--- a/src/parser.y
+++ b/src/parser.y
@@ -474,16 +474,13 @@ type-name
 abstract-declarator
 : pointer-list
 | pointer-list.opt direct-abstract-declarator
+| pointer-list.opt array-abstract-declarator
+| pointer-list.opt function-abstract-declarator
+| pointer-list.opt variadic-function-abstract-declarator
 ;
 
 direct-abstract-declarator
 : '(' abstract-declarator ')'
-| '[' constant-expression.opt ']'
-| direct-abstract-declarator '[' constant-expression.opt ']'
-| '(' parameter-declaration-list ')'
-| '(' parameter-declaration-list ',' "..." ')'
-| direct-abstract-declarator '(' parameter-declaration-list ')'
-| direct-abstract-declarator '(' parameter-declaration-list ',' "..." ')'
 ;
 
 array-abstract-declarator

--- a/src/parser.y
+++ b/src/parser.y
@@ -429,6 +429,14 @@ array-declarator
 | array-declarator '[' constant-expression.opt ']'
 ;
 
+function-declarator
+: direct-declarator '(' parameter-declaration-list ')'
+;
+
+variadic-function-declarator
+: direct-declarator '(' parameter-declaration-list ',' "..." ')'
+;
+
 pointer-list.opt
 : %empty
 | pointer-list

--- a/src/parser.y
+++ b/src/parser.y
@@ -259,6 +259,7 @@ constant-expression
 declaration
 : declaration-specifiers ';'
 | declaration-specifiers init-declarator-list ';'
+| storage-class-specifier declaration-specifiers init-declarator-list ';'
 ;
 
 declaration-specifiers.opt
@@ -267,8 +268,7 @@ declaration-specifiers.opt
 ;
 
 declaration-specifiers
-: storage-class-specifier declaration-specifiers.opt
-| type-specifier declaration-specifiers.opt
+: type-specifier declaration-specifiers.opt
 | type-qualifier declaration-specifiers.opt
 ;
 
@@ -524,6 +524,7 @@ external-declaration
 
 function-definition
 : declaration-specifiers declarator compound-statement
+| linkage-specifier declaration-specifiers declarator compound-statement
 ;
 
 %%

--- a/src/parser.y
+++ b/src/parser.y
@@ -265,6 +265,11 @@ declaration
 | storage-class-specifier declaration-specifiers init-declarator-list ';'
 ;
 
+global-declaration
+: declaration-specifiers init-declarator-list ';'
+| linkage-specifier declaration-specifiers init-declarator-list ';'
+;
+
 declaration-specifiers.opt
 : %empty
 | declaration-specifiers
@@ -523,6 +528,7 @@ translation-unit
 external-declaration
 : function-definition
 | type-declaration
+| global-declaration
 ;
 
 function-definition


### PR DESCRIPTION
ルールを制限してよりきれいな構文木ができるようにする。
